### PR TITLE
Fix/channel cache

### DIFF
--- a/lib/services/service.dart
+++ b/lib/services/service.dart
@@ -4,19 +4,20 @@ import 'package:tv_program/models/channel.dart';
 import 'package:tv_program/models/program.dart';
 
 class TvProgCache {
-  final List<Channel> _channelsCache = [];
+  final Map<String, List<Channel>> _channelsCache = {};
   final Map<String, List<Program>> _programsCache = {};
   final Map<String, Program?> _currentProgramCache = {};
   final Map<String, Program?> _tonightProgramCache = {};
 
-  List<Channel> get channels => _channelsCache;
+  List<Channel> getChannels(String package) => _channelsCache[package] ?? [];
   List<Program>? getPrograms(String channelId) => _programsCache[channelId];
   Program? getCurrentProgram(String channelId) =>
       _currentProgramCache[channelId];
   Program? getTonightProgram(String channelId) =>
       _tonightProgramCache[channelId];
 
-  void addChannels(List<Channel> channels) => _channelsCache.addAll(channels);
+  void addChannels(String package, List<Channel> channels) =>
+      _channelsCache[package] = channels;
   void addPrograms(String channelId, List<Program> programs) {
     _programsCache[channelId] = programs;
   }
@@ -39,13 +40,13 @@ class TvService {
   Future<List<Channel>> getChannels(String selectedProgram) async {
     debugPrint('Getting TV channels $selectedProgram');
 
-    if (cache.channels.isNotEmpty) {
+    if (cache.getChannels(selectedProgram).isNotEmpty) {
       debugPrint('Returning cached channels');
-      return cache.channels;
+      return cache.getChannels(selectedProgram);
     }
 
     var channels = await api.fetchChannels(selectedProgram);
-    cache.addChannels(channels);
+    cache.addChannels(selectedProgram, channels);
     return channels;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.1.0+15
+version: 2.1.1+16
 
 environment:
   sdk: '>=3.4.4 <4.0.0'


### PR DESCRIPTION
This pull request refactors the TV channel caching logic to support multiple packages and updates the version number of the app. The main change is switching from a single list cache to a map-based cache keyed by package name, which improves flexibility and correctness when handling channels for different packages.

**Caching logic improvements:**

* Changed the `TvProgCache` class to use a `Map<String, List<Channel>>` for `_channelsCache` instead of a single list, allowing channels to be cached per package. Added methods `getChannels(package)` and `addChannels(package, channels)` to manage this cache.
* Updated the `TvService.getChannels` method to use the new package-based cache logic, ensuring channels are retrieved and stored per selected program.

**Version update:**

* Bumped the app version from `2.1.0+15` to `2.1.1+16` in `pubspec.yaml`.